### PR TITLE
Override default onSurfaceSizeChanged

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
   supportLibraryVersion = '28.0.0'
   constrainLayoutVersion = '1.1.3'
   archLibraryVersion = '1.1.1'
-  exoPlayer2Version = '2.9.5'
+  exoPlayer2Version = '2.11.1'
   googleApiClient = '1.30.1'
   glide = '4.10.0'
   leackCanary = '1.6.3'

--- a/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/AdsExoPlayerViewHelper.java
+++ b/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/AdsExoPlayerViewHelper.java
@@ -18,7 +18,6 @@ package im.ene.toro.exoplayer;
 
 import android.content.Context;
 import android.net.Uri;
-import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.source.ads.AdsLoader;
@@ -42,7 +41,7 @@ public class AdsExoPlayerViewHelper extends ExoPlayerViewHelper {
       Uri contentUri,         //
       String fileExt,         //
       AdsLoader adsLoader,    //
-      ViewGroup adContainer   //
+      AdsLoader.AdViewProvider adContainer   //
   ) {
     return new AdsPlayable(creator, contentUri, fileExt, player, adsLoader, adContainer);
   }
@@ -53,7 +52,7 @@ public class AdsExoPlayerViewHelper extends ExoPlayerViewHelper {
       Uri contentUri,         //
       String fileExt,         //
       AdsLoader adsLoader,    //
-      ViewGroup adContainer   //
+      AdsLoader.AdViewProvider adContainer   //
   ) {
     Context context = player.getPlayerView().getContext();
     return createPlayable(player, ToroExo.with(context).getCreator(config), contentUri, fileExt,
@@ -65,7 +64,7 @@ public class AdsExoPlayerViewHelper extends ExoPlayerViewHelper {
       Uri contentUri,         //
       String fileExt,         //
       AdsLoader adsLoader,    //
-      ViewGroup adContainer   //
+      AdsLoader.AdViewProvider adContainer   //
   ) {
     Context context = player.getPlayerView().getContext();
     return createPlayable(player, ToroExo.with(context).getDefaultCreator(), contentUri, fileExt,
@@ -84,7 +83,7 @@ public class AdsExoPlayerViewHelper extends ExoPlayerViewHelper {
       @NonNull Uri uri,                 //
       @Nullable String fileExt,         //
       @NonNull AdsLoader adsLoader,     //
-      @Nullable ViewGroup adContainer   //
+      @Nullable AdsLoader.AdViewProvider adContainer   //
   ) {
     super(player, createPlayable(player, uri, fileExt, adsLoader, adContainer));
   }
@@ -101,7 +100,7 @@ public class AdsExoPlayerViewHelper extends ExoPlayerViewHelper {
       @NonNull Uri uri,                 //
       @Nullable String fileExt,         //
       @NonNull AdsLoader adsLoader,     //
-      @Nullable ViewGroup adContainer,  //
+      @Nullable AdsLoader.AdViewProvider adContainer,  //
       @NonNull ExoCreator creator       //
   ) {
     super(player, createPlayable(player, creator, uri, fileExt, adsLoader, adContainer));
@@ -119,7 +118,7 @@ public class AdsExoPlayerViewHelper extends ExoPlayerViewHelper {
       @NonNull Uri uri,                 //
       @Nullable String fileExt,         //
       @NonNull AdsLoader adsLoader,     //
-      @Nullable ViewGroup adContainer,  //
+      @Nullable AdsLoader.AdViewProvider adContainer,  //
       @NonNull Config config            //
   ) {
     super(player, createPlayable(player, config, uri, fileExt, adsLoader, adContainer));

--- a/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/AdsPlayable.java
+++ b/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/AdsPlayable.java
@@ -18,12 +18,12 @@ package im.ene.toro.exoplayer;
 
 import android.net.Uri;
 import android.view.View;
-import android.view.ViewGroup;
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.MediaSourceFactory;
 import com.google.android.exoplayer2.source.ads.AdsLoader;
 import com.google.android.exoplayer2.source.ads.AdsMediaSource;
 import com.google.android.exoplayer2.ui.PlayerView;
@@ -39,7 +39,7 @@ import im.ene.toro.annotations.Beta;
 @Beta //
 public class AdsPlayable extends ExoPlayable {
 
-  static class FactoryImpl implements AdsMediaSource.MediaSourceFactory {
+  static class FactoryImpl implements MediaSourceFactory {
 
     @NonNull final ExoCreator creator;
     @NonNull final ToroPlayer player;
@@ -61,11 +61,11 @@ public class AdsPlayable extends ExoPlayable {
 
   @NonNull private final AdsLoader adsLoader;
   @NonNull private final FactoryImpl factory;
-  @Nullable private final ViewGroup adsContainer;
+  @Nullable private final AdsLoader.AdViewProvider adsContainer;
 
   @SuppressWarnings("WeakerAccess")
   public AdsPlayable(ExoCreator creator, Uri uri, String fileExt, ToroPlayer player,
-      @NonNull AdsLoader adsLoader, @Nullable ViewGroup adsContainer) {
+      @NonNull AdsLoader adsLoader, @Nullable AdsLoader.AdViewProvider adsContainer) {
     super(creator, uri, fileExt);
     this.adsLoader = adsLoader;
     this.adsContainer = adsContainer;
@@ -80,8 +80,8 @@ public class AdsPlayable extends ExoPlayable {
   }
 
   private static MediaSource createAdsMediaSource(ExoCreator creator, Uri uri, String fileExt,
-      ToroPlayer player, AdsLoader adsLoader, ViewGroup adContainer,
-      AdsMediaSource.MediaSourceFactory factory) {
+      ToroPlayer player, AdsLoader adsLoader, AdsLoader.AdViewProvider adContainer,
+      MediaSourceFactory factory) {
     MediaSource original = creator.createMediaSource(uri, fileExt);
     View playerView = player.getPlayerView();
     if (!(playerView instanceof PlayerView)) {
@@ -89,6 +89,6 @@ public class AdsPlayable extends ExoPlayable {
     }
 
     return new AdsMediaSource(original, factory, adsLoader,
-        adContainer == null ? ((PlayerView) playerView).getOverlayFrameLayout() : adContainer);
+        adContainer == null ? (PlayerView) playerView : adContainer);
   }
 }

--- a/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/DefaultExoCreator.java
+++ b/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/DefaultExoCreator.java
@@ -21,10 +21,14 @@ import android.net.Uri;
 import android.os.Handler;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.ObjectsCompat;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.LoadControl;
 import com.google.android.exoplayer2.RenderersFactory;
 import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.analytics.AnalyticsCollector;
+import com.google.android.exoplayer2.drm.DrmSessionManager;
+import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
@@ -34,6 +38,7 @@ import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.cache.CacheDataSourceFactory;
+import com.google.android.exoplayer2.util.Clock;
 import com.google.android.exoplayer2.util.Util;
 import java.io.IOException;
 
@@ -58,15 +63,20 @@ public class DefaultExoCreator implements ExoCreator, MediaSourceEventListener {
   private final RenderersFactory renderersFactory;  // stateless
   private final DataSource.Factory mediaDataSourceFactory;  // stateless
   private final DataSource.Factory manifestDataSourceFactory; // stateless
+  private final DrmSessionManager<FrameworkMediaCrypto> drmSessionManager; // stateless
+  private final Clock clock; // stateless
 
   @SuppressWarnings("unchecked")  //
   public DefaultExoCreator(@NonNull ToroExo toro, @NonNull Config config) {
     this.toro = checkNotNull(toro);
     this.config = checkNotNull(config);
-    trackSelector = new DefaultTrackSelector();
+    trackSelector = new DefaultTrackSelector(this.toro.context);
     loadControl = config.loadControl;
     mediaSourceBuilder = config.mediaSourceBuilder;
-    renderersFactory = new DefaultRenderersFactory(this.toro.context, config.extensionMode);
+    drmSessionManager = config.drmSessionManager;
+    clock = config.clock;
+    renderersFactory = new DefaultRenderersFactory(this.toro.context)
+        .setExtensionRendererMode(config.extensionMode);
     DataSource.Factory baseFactory = config.dataSourceFactory;
     if (baseFactory == null) {
       baseFactory = new DefaultHttpDataSourceFactory(toro.appName, config.meter);
@@ -94,7 +104,9 @@ public class DefaultExoCreator implements ExoCreator, MediaSourceEventListener {
     if (!mediaSourceBuilder.equals(that.mediaSourceBuilder)) return false;
     if (!renderersFactory.equals(that.renderersFactory)) return false;
     if (!mediaDataSourceFactory.equals(that.mediaDataSourceFactory)) return false;
-    return manifestDataSourceFactory.equals(that.manifestDataSourceFactory);
+    if (!manifestDataSourceFactory.equals(that.manifestDataSourceFactory)) return false;
+    if (!ObjectsCompat.equals(drmSessionManager, that.drmSessionManager)) return false;
+    return clock.equals(that.clock);
   }
 
   @Override public int hashCode() {
@@ -105,6 +117,8 @@ public class DefaultExoCreator implements ExoCreator, MediaSourceEventListener {
     result = 31 * result + renderersFactory.hashCode();
     result = 31 * result + mediaDataSourceFactory.hashCode();
     result = 31 * result + manifestDataSourceFactory.hashCode();
+    result = 31 * result + (drmSessionManager != null ? drmSessionManager.hashCode() : 0);
+    result = 31 * result + clock.hashCode();
     return result;
   }
 
@@ -118,12 +132,13 @@ public class DefaultExoCreator implements ExoCreator, MediaSourceEventListener {
 
   @NonNull @Override public SimpleExoPlayer createPlayer() {
     return new ToroExoPlayer(toro.context, renderersFactory, trackSelector, loadControl,
-        new DefaultBandwidthMeter(), config.drmSessionManager, Util.getLooper());
+        new DefaultBandwidthMeter.Builder(toro.context).build(),
+        new AnalyticsCollector(clock), clock, Util.getLooper());
   }
 
   @NonNull @Override public MediaSource createMediaSource(@NonNull Uri uri, String fileExt) {
     return mediaSourceBuilder.buildMediaSource(this.toro.context, uri, fileExt, new Handler(),
-        manifestDataSourceFactory, mediaDataSourceFactory, this);
+        manifestDataSourceFactory, mediaDataSourceFactory, drmSessionManager, this);
   }
 
   @NonNull @Override //

--- a/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/ExoPlayable.java
+++ b/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/ExoPlayable.java
@@ -146,7 +146,7 @@ public class ExoPlayable extends PlayableImpl {
           // Special case for decoder initialization failures.
           MediaCodecRenderer.DecoderInitializationException decoderInitializationException =
               (MediaCodecRenderer.DecoderInitializationException) cause;
-          if (decoderInitializationException.decoderName == null) {
+          if (decoderInitializationException.codecInfo == null) {
             if (decoderInitializationException.getCause() instanceof MediaCodecUtil.DecoderQueryException) {
               errorString = toro.getString(R.string.error_querying_decoders);
             } else if (decoderInitializationException.secureDecoderRequired) {
@@ -158,7 +158,7 @@ public class ExoPlayable extends PlayableImpl {
             }
           } else {
             errorString = toro.getString(R.string.error_instantiating_decoder,
-                decoderInitializationException.decoderName);
+                decoderInitializationException.codecInfo.name);
           }
         }
       }

--- a/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/MediaSourceBuilder.java
+++ b/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/MediaSourceBuilder.java
@@ -23,10 +23,12 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.C.ContentType;
-import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.google.android.exoplayer2.drm.DrmSessionManager;
+import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.source.LoopingMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceEventListener;
+import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
@@ -48,6 +50,7 @@ public interface MediaSourceBuilder {
       @Nullable String fileExt, @Nullable Handler handler,
       @NonNull DataSource.Factory manifestDataSourceFactory,
       @NonNull DataSource.Factory mediaDataSourceFactory,
+      @Nullable DrmSessionManager<FrameworkMediaCrypto> drmSessionManager,
       @Nullable MediaSourceEventListener listener);
 
   MediaSourceBuilder DEFAULT = new MediaSourceBuilder() {
@@ -55,27 +58,36 @@ public interface MediaSourceBuilder {
     public MediaSource buildMediaSource(@NonNull Context context, @NonNull Uri uri,
         @Nullable String ext, @Nullable Handler handler,
         @NonNull DataSource.Factory manifestDataSourceFactory,
-        @NonNull DataSource.Factory mediaDataSourceFactory, MediaSourceEventListener listener) {
+        @NonNull DataSource.Factory mediaDataSourceFactory,
+        @Nullable DrmSessionManager<FrameworkMediaCrypto> drmSessionManager,
+        MediaSourceEventListener listener) {
       @ContentType int type = isEmpty(ext) ? inferContentType(uri) : inferContentType("." + ext);
       MediaSource result;
       switch (type) {
         case C.TYPE_SS:
-          result = new SsMediaSource.Factory( //
-              new DefaultSsChunkSource.Factory(mediaDataSourceFactory), manifestDataSourceFactory)//
-              .createMediaSource(uri);
+          SsMediaSource.Factory factory =
+              new SsMediaSource.Factory(new DefaultSsChunkSource.Factory(mediaDataSourceFactory),
+                  manifestDataSourceFactory);
+          if (drmSessionManager != null) factory.setDrmSessionManager(drmSessionManager);
+          result = factory.createMediaSource(uri);
           break;
         case C.TYPE_DASH:
-          result = new DashMediaSource.Factory(
-              new DefaultDashChunkSource.Factory(mediaDataSourceFactory), manifestDataSourceFactory)
-              .createMediaSource(uri);
+          DashMediaSource.Factory factory1 = new DashMediaSource.Factory(
+              new DefaultDashChunkSource.Factory(mediaDataSourceFactory),
+              manifestDataSourceFactory);
+          if (drmSessionManager != null) factory1.setDrmSessionManager(drmSessionManager);
+          result = factory1.createMediaSource(uri);
           break;
         case C.TYPE_HLS:
-          result = new HlsMediaSource.Factory(mediaDataSourceFactory) //
-              .createMediaSource(uri);
+          HlsMediaSource.Factory factory2 = new HlsMediaSource.Factory(mediaDataSourceFactory);
+          if (drmSessionManager != null) factory2.setDrmSessionManager(drmSessionManager);
+          result =  factory2.createMediaSource(uri);
           break;
         case C.TYPE_OTHER:
-          result = new ExtractorMediaSource.Factory(mediaDataSourceFactory) //
-              .createMediaSource(uri);
+          ProgressiveMediaSource.Factory factory3 =
+              new ProgressiveMediaSource.Factory(mediaDataSourceFactory);
+          if (drmSessionManager != null) factory3.setDrmSessionManager(drmSessionManager);
+          result =  factory3.createMediaSource(uri);
           break;
         default:
           throw new IllegalStateException("Unsupported type: " + type);
@@ -93,10 +105,11 @@ public interface MediaSourceBuilder {
         @Nullable String fileExt, @Nullable Handler handler,
         @NonNull DataSource.Factory manifestDataSourceFactory,
         @NonNull DataSource.Factory mediaDataSourceFactory,
+        @Nullable DrmSessionManager<FrameworkMediaCrypto> drmSessionManager,
         @Nullable MediaSourceEventListener listener) {
       return new LoopingMediaSource(
           DEFAULT.buildMediaSource(context, uri, fileExt, handler, manifestDataSourceFactory,
-              mediaDataSourceFactory, listener));
+              mediaDataSourceFactory, drmSessionManager, listener));
     }
   };
 }

--- a/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/Playable.java
+++ b/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/Playable.java
@@ -253,6 +253,11 @@ public interface Playable {
 
     }
 
+    @Override
+    public void onSurfaceSizeChanged(int width, int height) {
+
+    }
+
     @Override public void onRenderedFirstFrame() {
 
     }
@@ -277,6 +282,13 @@ public interface Playable {
       for (EventListener eventListener : this) {
         eventListener.onVideoSizeChanged(width, height, unAppliedRotationDegrees,
             pixelWidthHeightRatio);
+      }
+    }
+
+    @Override
+    public void onSurfaceSizeChanged(int width, int height) {
+      for (EventListener eventListener : this) {
+        eventListener.onSurfaceSizeChanged(width, height);
       }
     }
 

--- a/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/ToroExoPlayer.java
+++ b/toro-exoplayer/src/main/java/im/ene/toro/exoplayer/ToroExoPlayer.java
@@ -20,14 +20,13 @@ import android.content.Context;
 import android.os.Looper;
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.LoadControl;
 import com.google.android.exoplayer2.RenderersFactory;
 import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.drm.DrmSessionManager;
-import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
+import com.google.android.exoplayer2.analytics.AnalyticsCollector;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
+import com.google.android.exoplayer2.util.Clock;
 import im.ene.toro.ToroPlayer;
 import im.ene.toro.media.VolumeInfo;
 
@@ -43,9 +42,9 @@ public class ToroExoPlayer extends SimpleExoPlayer {
 
   protected ToroExoPlayer(Context context, RenderersFactory renderersFactory,
       TrackSelector trackSelector, LoadControl loadControl, BandwidthMeter bandwidthMeter,
-      @Nullable DrmSessionManager<FrameworkMediaCrypto> drmSessionManager, Looper looper) {
-    super(context, renderersFactory, trackSelector, loadControl, bandwidthMeter, drmSessionManager,
-        looper);
+      AnalyticsCollector analyticsCollector, Clock clock, Looper looper) {
+    super(context, renderersFactory, trackSelector, loadControl, bandwidthMeter,
+        analyticsCollector, clock, looper);
   }
 
   private ToroPlayer.VolumeChangeListeners listeners;


### PR DESCRIPTION
Latest Toro player defines a new `VideoListener.onSurfaceSizeChanged(int width, int height)` with a default empty implementation that we need to override so that Toro notifies each one of the their own event listeners.